### PR TITLE
Fix navigation bugs

### DIFF
--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -447,7 +447,8 @@ private:
   // flags
   bool initialized_; //!< Keeps track about the correct initialization of this class
 
-  int cur_global_plan_index_;
+  int first_prune_g_plan_index_;        //! the first pose index to be pruned on the global path
+  int search_start_g_plan_index_;        //! the index of global plan poses for searching the closest point with the robot pose
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -447,9 +447,6 @@ private:
   // flags
   bool initialized_; //!< Keeps track about the correct initialization of this class
 
-  int first_prune_g_plan_index_;        //! the first pose index to be pruned on the global path
-  int search_start_g_plan_index_;        //! the index of global plan poses for searching the closest point with the robot pose
-
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -223,7 +223,11 @@ public:
   //@}
   
 protected:
-
+  enum TransformResult {
+    TRANS_FAILURE = -1,
+    TRANS_SUCEESS = 0,
+    TRANS_NEED_REPLAN_GLOBAL_PATH = 1,
+  };
   /**
     * @brief Update internal obstacle vector based on occupied costmap cells
     * @remarks All occupied cells will be added as point obstacles.
@@ -316,10 +320,10 @@ protected:
     * @param[out] tf_plan_to_global Transformation between the global plan and the global planning frame
     * @return \c true if the global plan is transformed, \c false otherwise
     */
-  bool transformGlobalPlan(const tf2_ros::Buffer& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
-                           const geometry_msgs::PoseStamped& global_pose,  const costmap_2d::Costmap2D& costmap,
-                           const std::string& global_frame, double max_plan_length, std::vector<geometry_msgs::PoseStamped>& transformed_plan,
-                           int* current_goal_idx = NULL, geometry_msgs::TransformStamped* tf_plan_to_global = NULL) const;
+  TransformResult transformGlobalPlan(const tf2_ros::Buffer& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
+                                      const geometry_msgs::PoseStamped& global_pose,  const costmap_2d::Costmap2D& costmap,
+                                      const std::string& global_frame, double max_plan_length, std::vector<geometry_msgs::PoseStamped>& transformed_plan,
+                                      int* current_goal_idx = NULL, geometry_msgs::TransformStamped* tf_plan_to_global = NULL);
     
   /**
     * @brief Estimate the orientation of a pose from the global_plan that is treated as a local goal for the local planner.
@@ -442,6 +446,8 @@ private:
     
   // flags
   bool initialized_; //!< Keeps track about the correct initialization of this class
+
+  int cur_global_plan_index_;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -69,7 +69,7 @@ namespace teb_local_planner
 TebLocalPlannerROS::TebLocalPlannerROS() : costmap_ros_(NULL), tf_(NULL), costmap_model_(NULL),
                                            costmap_converter_loader_("costmap_converter", "costmap_converter::BaseCostmapToPolygons"),
                                            dynamic_recfg_(NULL), custom_via_points_active_(false), goal_reached_(false), no_infeasible_plans_(0),
-                                           last_preferred_rotdir_(RotType::none), initialized_(false)
+                                           last_preferred_rotdir_(RotType::none), initialized_(false), cur_global_plan_index_(0)
 {
 }
 
@@ -148,7 +148,7 @@ void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costm
         costmap_converter_.reset();
       }
     }
-    else 
+    else
       ROS_INFO("No costmap conversion plugin specified. All occupied costmap cells are treaten as point obstacles.");
   
     
@@ -204,13 +204,14 @@ bool TebLocalPlannerROS::setPlan(const std::vector<geometry_msgs::PoseStamped>& 
   // store the global plan
   global_plan_.clear();
   global_plan_ = orig_global_plan;
+  cur_global_plan_index_ = 0;
 
   // we do not clear the local planner here, since setPlan is called frequently whenever the global planner updates the plan.
   // the local planner checks whether it is required to reinitialize the trajectory or not within each velocity computation step.  
             
   // reset goal_reached_ flag
   goal_reached_ = false;
-  
+
   return true;
 }
 
@@ -222,7 +223,7 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
   geometry_msgs::TwistStamped dummy_velocity, cmd_vel_stamped;
   uint32_t outcome = computeVelocityCommands(dummy_pose, dummy_velocity, cmd_vel_stamped, dummy_message);
   cmd_vel = cmd_vel_stamped.twist;
-  return outcome == mbf_msgs::ExePathResult::SUCCESS;
+  return outcome < mbf_msgs::ExePathResult::FAILURE;
 }
 
 uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
@@ -264,13 +265,19 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   std::vector<geometry_msgs::PoseStamped> transformed_plan;
   int goal_idx;
   geometry_msgs::TransformStamped tf_plan_to_global;
-  if (!transformGlobalPlan(*tf_, global_plan_, robot_pose, *costmap_, global_frame_, cfg_.trajectory.max_global_plan_lookahead_dist, 
-                           transformed_plan, &goal_idx, &tf_plan_to_global))
+  TransformResult transform_result = transformGlobalPlan(*tf_, global_plan_, robot_pose, *costmap_, global_frame_, cfg_.trajectory.max_global_plan_lookahead_dist,
+                                                         transformed_plan, &goal_idx, &tf_plan_to_global);
+  if (TRANS_FAILURE == transform_result)
   {
     ROS_WARN("Could not transform the global plan to the frame of the controller");
     message = "Could not transform the global plan to the frame of the controller";
     return mbf_msgs::ExePathResult::INTERNAL_ERROR;
   }
+  uint32_t exe_path_result = mbf_msgs::ExePathResult::SUCCESS;
+  if(transform_result == TransformResult::TRANS_NEED_REPLAN_GLOBAL_PATH) {
+      exe_path_result = mbf_msgs::ExePathResult::NEED_REPLAN_GLOBAL_PATH;
+  }
+
 
   // update via-points container
   if (!custom_via_points_active_)
@@ -287,7 +294,7 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
     && (!cfg_.goal_tolerance.complete_global_plan || via_points_.size() == 0))
   {
     goal_reached_ = true;
-    return mbf_msgs::ExePathResult::SUCCESS;
+    return exe_path_result;
   }
   
   
@@ -429,7 +436,7 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   visualization_->publishObstacles(obstacles_);
   visualization_->publishViaPoints(via_points_);
   visualization_->publishGlobalPlan(global_plan_);
-  return mbf_msgs::ExePathResult::SUCCESS;
+  return exe_path_result;
 }
 
 
@@ -629,49 +636,22 @@ bool TebLocalPlannerROS::pruneGlobalPlan(const tf2_ros::Buffer& tf, const geomet
 {
   if (global_plan.empty())
     return true;
-  
-  try
-  {
-    // transform robot pose into the plan frame (we do not wait here, since pruning not crucial, if missed a few times)
-    geometry_msgs::TransformStamped global_to_plan_transform = tf.lookupTransform(global_plan.front().header.frame_id, global_pose.header.frame_id, ros::Time(0));
-    geometry_msgs::PoseStamped robot;
-    tf2::doTransform(global_pose, robot, global_to_plan_transform);
-    
-    double dist_thresh_sq = dist_behind_robot*dist_behind_robot;
-    
-    // iterate plan until a pose close the robot is found
-    std::vector<geometry_msgs::PoseStamped>::iterator it = global_plan.begin();
-    std::vector<geometry_msgs::PoseStamped>::iterator erase_end = it;
-    while (it != global_plan.end())
-    {
-      double dx = robot.pose.position.x - it->pose.position.x;
-      double dy = robot.pose.position.y - it->pose.position.y;
-      double dist_sq = dx * dx + dy * dy;
-      if (dist_sq < dist_thresh_sq)
-      {
-         erase_end = it;
-         break;
-      }
-      ++it;
-    }
-    if (erase_end == global_plan.end())
-      return false;
-    
-    if (erase_end != global_plan.begin())
-      global_plan.erase(global_plan.begin(), erase_end);
+
+  std::vector<geometry_msgs::PoseStamped>::const_iterator iter = global_plan.begin();
+  int i = 0;
+  while(++i < cur_global_plan_index_) {
+    ++iter;
   }
-  catch (const tf::TransformException& ex)
-  {
-    ROS_DEBUG("Cannot prune path since no transform is available: %s\n", ex.what());
-    return false;
-  }
+  global_plan.erase(global_plan.begin(), iter);
+  cur_global_plan_index_ = 0;
+
   return true;
 }
       
 
-bool TebLocalPlannerROS::transformGlobalPlan(const tf2_ros::Buffer& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
+TebLocalPlannerROS::TransformResult TebLocalPlannerROS::transformGlobalPlan(const tf2_ros::Buffer& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
                   const geometry_msgs::PoseStamped& global_pose, const costmap_2d::Costmap2D& costmap, const std::string& global_frame, double max_plan_length,
-                  std::vector<geometry_msgs::PoseStamped>& transformed_plan, int* current_goal_idx, geometry_msgs::TransformStamped* tf_plan_to_global) const
+                  std::vector<geometry_msgs::PoseStamped>& transformed_plan, int* current_goal_idx, geometry_msgs::TransformStamped* tf_plan_to_global) 
 {
   // this method is a slightly modified version of base_local_planner/goal_functions.h
 
@@ -679,13 +659,14 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf2_ros::Buffer& tf, const st
 
   transformed_plan.clear();
 
+  bool is_find_obstacle = false;
   try 
   {
     if (global_plan.empty())
     {
       ROS_ERROR("Received plan with zero length");
       *current_goal_idx = 0;
-      return false;
+      return TRANS_FAILURE;
     }
 
     // get plan_to_global_transform from plan frame to global_frame
@@ -703,49 +684,60 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf2_ros::Buffer& tf, const st
                            // located on the border of the local costmap
     
 
-    int i = 0;
-    double sq_dist_threshold = dist_threshold * dist_threshold;
-    double sq_dist = 1e10;
-    
-    //we need to loop to a point on the plan that is within a certain distance of the robot
-    for(int j=0; j < (int)global_plan.size(); ++j)
-    {
-      double x_diff = robot_pose.pose.position.x - global_plan[j].pose.position.x;
-      double y_diff = robot_pose.pose.position.y - global_plan[j].pose.position.y;
-      double new_sq_dist = x_diff * x_diff + y_diff * y_diff;
-      if (new_sq_dist > sq_dist_threshold)
-        break;  // force stop if we have reached the costmap border
+    //Find the closest point ont the plan that is not reached yet
+    const int max_plan_index = global_plan.size() - 1;
+    double move_dir_x, move_dir_y = 0.0;
+    double dir_x1, dir_y1 = 0.0;
+    double product1;
+    int i = cur_global_plan_index_;
+    while(i < max_plan_index) {
+        move_dir_x = global_plan[i + 1].pose.position.x - global_plan[i].pose.position.x;
+        move_dir_y = global_plan[i + 1].pose.position.y - global_plan[i].pose.position.y;
+        dir_x1 = global_plan[i].pose.position.x - robot_pose.pose.position.x;
+        dir_y1 = global_plan[i].pose.position.y - robot_pose.pose.position.y;
 
-      if (new_sq_dist < sq_dist) // find closest distance
-      {
-        sq_dist = new_sq_dist;
-        i = j;
-      }
+        product1 = dir_x1 * move_dir_x + dir_y1 * move_dir_y;
+        if(product1 < 0.0) {
+            ++i;
+            continue;
+        }
+        else {
+            cur_global_plan_index_ = i;
+            break;
+        }
     }
     
     geometry_msgs::PoseStamped newer_pose;
     
     double plan_length = 0; // check cumulative Euclidean distance along the plan
-    
+
+    //whether find a point on the global plan that conflicts with obstacles
     //now we'll transform until points are outside of our distance threshold
-    while(i < (int)global_plan.size() && sq_dist <= sq_dist_threshold && (max_plan_length<=0 || plan_length <= max_plan_length))
+    unsigned int x0, y0;
+    while(plan_length <= max_plan_length || max_plan_length<=0)
     {
+      if(i > max_plan_index) {
+        break;
+      }
       const geometry_msgs::PoseStamped& pose = global_plan[i];
       tf2::doTransform(pose, newer_pose, plan_to_global_transform);
+      if(!is_find_obstacle) {
+          if(costmap_->worldToMap(newer_pose.pose.position.x, newer_pose.pose.position.y, x0, y0)) {
+              if(costmap_model_->pointCost(x0, y0) == -1.0) {
+                is_find_obstacle = true;
+              }
+          }
+      }
 
       transformed_plan.push_back(newer_pose);
 
-      double x_diff = robot_pose.pose.position.x - global_plan[i].pose.position.x;
-      double y_diff = robot_pose.pose.position.y - global_plan[i].pose.position.y;
-      sq_dist = x_diff * x_diff + y_diff * y_diff;
-      
       // caclulate distance to previous pose
       if (i>0 && max_plan_length>0)
         plan_length += distance_points2d(global_plan[i-1].pose.position, global_plan[i].pose.position);
 
       ++i;
     }
-        
+
     // if we are really close to the goal (<sq_dist_threshold) and the goal is not yet reached (e.g. orientation error >>0)
     // the resulting transformed plan can be empty. In that case we explicitly inject the global goal.
     if (transformed_plan.empty())
@@ -769,12 +761,12 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf2_ros::Buffer& tf, const st
   catch(tf::LookupException& ex)
   {
     ROS_ERROR("No Transform available Error: %s\n", ex.what());
-    return false;
+    return TRANS_FAILURE;
   }
   catch(tf::ConnectivityException& ex) 
   {
     ROS_ERROR("Connectivity Error: %s\n", ex.what());
-    return false;
+    return TRANS_FAILURE;
   }
   catch(tf::ExtrapolationException& ex) 
   {
@@ -782,10 +774,15 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf2_ros::Buffer& tf, const st
     if (global_plan.size() > 0)
       ROS_ERROR("Global Frame: %s Plan Frame size %d: %s\n", global_frame.c_str(), (unsigned int)global_plan.size(), global_plan[0].header.frame_id.c_str());
 
-    return false;
+    return TRANS_FAILURE;
   }
 
-  return true;
+  if(is_find_obstacle) {
+      return TRANS_NEED_REPLAN_GLOBAL_PATH;
+  }
+  else {
+      return TRANS_SUCEESS;
+  }
 }
 
     

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -385,7 +385,7 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
     time_last_infeasible_plan_ = ros::Time::now();
     last_cmd_ = cmd_vel.twist;
     message = "teb_local_planner trajectory is not feasible";
-    return mbf_msgs::ExePathResult::NO_VALID_CMD;
+    return mbf_msgs::ExePathResult::LOCAL_TRAJ_NOT_FEASIBLE;
   }
 
   // Get the velocity command for this sampling interval


### PR DESCRIPTION
1.Send global planning request when local planning is not feasible.
2.global path replanning problem: Change global replanning rate to 0 and inform the global planner to replan when detecting obstacle on the global path.
3.Fix bugs:
    Fixes RockRobo/RoboticFloorScrubber#267
    Fixes      @@@@@RockRobo/RoboticFloorScrubber#274
    Fixes RockRobo/RoboticFloorScrubber#378
    Fixes RockRobo/RoboticFloorScrubber#381
